### PR TITLE
Fix issue #1: Create Github Actions Workflow for dev and main and publish to pypi

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,42 @@
+name: Development CI
+
+on:
+  push:
+    branches: [ dev ]
+  pull_request:
+    branches: [ dev ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install pytest pytest-cov flake8
+
+    - name: Run linting
+      run: |
+        flake8 yt_transcript tests --max-line-length=120
+
+    - name: Run tests
+      run: |
+        pytest tests/ --cov=yt_transcript --cov-report=xml
+
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release to PyPI
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.12"
+        cache: 'pip'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build twine
+
+    - name: Build package
+      run: python -m build
+
+    - name: Check distribution
+      run: twine check dist/*
+
+    - name: Publish to PyPI
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      run: twine upload dist/*


### PR DESCRIPTION
This pull request fixes #1.

The changes fully address all requirements specified in the issue:

1. Branch-specific workflows are correctly implemented:
   - dev.yml handles testing/linting on dev branch
   - release.yml handles publishing on main branch

2. Test and lint requirements are met in dev.yml:
   - Implements pytest with coverage reporting
   - Implements flake8 linting
   - Triggers on both push and PR events to dev branch
   - Tests across multiple Python versions (3.8-3.12)

3. Publishing requirements are met in release.yml:
   - Triggers on push to main branch
   - Builds package using python-build
   - Validates distribution with twine
   - Publishes to PyPI

4. Security requirements are met:
   - Uses GitHub secrets for PyPI authentication (PYPI_API_TOKEN)
   - Properly configures token-based authentication for PyPI

5. Performance optimization is implemented:
   - Both workflows use pip caching via actions/setup-python's cache parameter
   - This will speed up dependency installation across runs

The workflows are properly structured, use modern GitHub Actions features (like v4 of checkout and setup-python), and follow best practices for Python package CI/CD. The implementation is complete and should work as intended once the required secrets are configured.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌